### PR TITLE
create-certs: run kubectl with sudo

### DIFF
--- a/create-certs.sh
+++ b/create-certs.sh
@@ -10,7 +10,7 @@ openssl req -new -key ./webhookCA.key -subj "/CN=${WEBHOOK_SVC}.${WEBHOOK_NS}.sv
 openssl x509 -req -days 365 -in webhookCA.csr -signkey webhookCA.key -out webhook.crt
 
 # Create certs secrets for k8s
-kubectl create secret generic \
+sudo -E kubectl create secret generic \
     ${WEBHOOK_SVC}-certs \
     --from-file=key.pem=./webhookCA.key \
     --from-file=cert.pem=./webhook.crt \


### PR DESCRIPTION
run kubectl with `sudo -E`, just to make sure this would
work when running with a normal user.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>